### PR TITLE
refactor: replace any with specific types

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -28,11 +28,24 @@ import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
 import { getAuthHeaders } from "@/lib/telegram";
 
+interface TournamentFormData {
+  title: string;
+  description: string;
+  mapName: string;
+  mapImage: string;
+  date: string;
+  entryFee: string;
+  prize: string;
+  maxParticipants: string;
+  status: "upcoming" | "active" | "completed";
+  tournamentType: string;
+}
+
 export default function AdminPage() {
   const [, setLocation] = useLocation();
   const { toast } = useToast();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<TournamentFormData>({
     title: "",
     description: "",
     mapName: "",
@@ -57,7 +70,7 @@ export default function AdminPage() {
 
   // Create tournament mutation
   const createTournamentMutation = useMutation({
-    mutationFn: async (data: any) => {
+    mutationFn: async (data: TournamentFormData) => {
       const response = await fetch("/api/tournaments", {
         method: "POST",
         headers: {
@@ -432,7 +445,7 @@ export default function AdminPage() {
                           size="sm"
                           variant="ghost"
                           className="p-1 h-auto"
-                          onClick={() => handleDelete(tournament.id, tournament.title)}
+                          onClick={() => handleDelete(tournament.id)}
                           disabled={deleteTournamentMutation.isPending}
                         >
                           <Trash2 className="w-4 h-4 text-red-600" />

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,7 +1,7 @@
 // Shared types and interfaces for the WZ Tournament Platform
 
 // API Response types
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;
@@ -18,16 +18,16 @@ export interface PaginatedResponse<T> extends ApiResponse<T[]> {
 }
 
 // WebSocket message types
-export interface WebSocketMessage<T = any> {
+export interface WebSocketMessage<T = unknown> {
   type: "tournament_update" | "user_update" | "notification" | "error";
   payload: T;
   timestamp: string;
 }
 
-export interface TournamentUpdateMessage {
+export interface TournamentUpdateMessage<T = unknown> {
   tournamentId: string;
   type: "participant_joined" | "participant_left" | "status_changed" | "prize_updated";
-  data: any;
+  data: T;
 }
 
 // Tournament related types
@@ -99,7 +99,7 @@ export type RequiredKeys<T> = {
 export interface AnalyticsEvent {
   event: string;
   userId?: string;
-  properties: Record<string, any>;
+  properties: Record<string, unknown>;
   timestamp: string;
 }
 
@@ -107,7 +107,7 @@ export interface AnalyticsEvent {
 export interface AppError {
   code: string;
   message: string;
-  details?: any;
+  details?: unknown;
   stack?: string;
 }
 


### PR DESCRIPTION
## Summary
- replace loose `any` usages in shared types with generics and `unknown`
- add `TournamentFormData` interface to admin page and update handlers

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c18221e1c8327b7e52cf07076783c