### PR TITLE
feat(server): add seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ cp .env.example .env
 npm run db:push
 ```
 
-5. Start the development server:
+5. (Optional) Seed demo tournaments:
+
+```bash
+npm run seed
+```
+
+6. Start the development server:
 
 ```bash
 npm run dev
@@ -99,6 +105,7 @@ The application will be available at `http://localhost:5173`
 - `npm run start` - Start production server
 - `npm run check` - Type check with TypeScript
 - `npm run db:push` - Push database schema changes
+- `npm run seed` - Seed demo tournaments with sample data
 
 ## 🏆 Tournament Features
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:check": "eslint . --max-warnings=0",
     "prepare": "if [ -z \"$CI\" ]; then npm run validate; fi",
     "start": "NODE_ENV=production node dist/index.js",
+    "seed": "NODE_ENV=development tsx server/seed.ts",
     "test": "echo \"Add test script here\"",
     "test:coverage": "echo \"Add test coverage script here\"",
     "type-check": "tsc --noEmit",

--- a/server/README.md
+++ b/server/README.md
@@ -52,6 +52,9 @@ npm run start
 # Push schema changes to database
 npm run db:push
 
+# Seed demo tournaments (optional)
+npm run seed
+
 # View database configuration
 cat drizzle.config.ts
 ```

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -3,7 +3,7 @@ import { storage } from './storage';
 async function seed() {
   try {
     await storage.initializeData();
-    console.log('Demo tournaments seeded successfully.');
+    console.log('Sample tournaments seeded successfully.');
     process.exit(0);
   } catch (error) {
     console.error('Failed to seed demo tournaments:', error);

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -1,0 +1,14 @@
+import { storage } from './storage';
+
+async function seed() {
+  try {
+    await storage.initializeData();
+    console.log('Demo tournaments seeded successfully.');
+    process.exit(0);
+  } catch (error) {
+    console.error('Failed to seed demo tournaments:', error);
+    process.exit(1);
+  }
+}
+
+seed();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -258,6 +258,3 @@ export class DatabaseStorage implements IStorage {
 }
 
 export const storage = new DatabaseStorage();
-
-// Initialize sample data on startup
-storage.initializeData().catch(console.error);


### PR DESCRIPTION
## Summary
- remove automatic call to `initializeData` from storage
- add dedicated seeding script and npm command
- document how to seed demo tournaments

## Testing
- `npm test`
- `npm run lint:check`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689cd877c9dc83279fb651eb3560cbb4