### PR TITLE
chore: simplify environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,15 +8,9 @@ DATABASE_URL=postgresql://username:password@localhost:5432/wz_tournaments
 # Session Configuration (REQUIRED - Generate with: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))")
 SESSION_SECRET=your-super-secret-session-key-change-this-in-production-at-least-32-chars
 
-# Telegram Configuration (REQUIRED)
+# Telegram Configuration
 TELEGRAM_BOT_TOKEN=1234567890:ABCdefGHIjklMNOpqrsTUVwxyz
 ADMIN_TELEGRAM_ID=123456789
-TELEGRAM_WEBHOOK_URL=https://yourdomain.com/api/telegram/webhook
-
-# Development Settings (Optional)
-SKIP_TELEGRAM_VALIDATION=false
-# Set to true to disable all rate limiting (use with caution)
-SKIP_RATE_LIMITING=false
 
 # Frontend Configuration (VITE_ prefix required for client access)
 VITE_API_URL=http://localhost:3000/api
@@ -25,56 +19,9 @@ VITE_APP_NAME=WZ Tournament Platform
 VITE_APP_VERSION=1.0.0
 VITE_TELEGRAM_BOT_NAME=your_bot_name
 
-# Security Settings
-CORS_ORIGIN=http://localhost:5173
-BCRYPT_ROUNDS=12
-
-# File Upload Settings
-MAX_FILE_SIZE=10MB
-UPLOAD_DIR=./uploads
-ALLOWED_FILE_TYPES=image/jpeg,image/png,image/gif,image/webp
-
-# Redis Configuration (for session store in production)
-REDIS_URL=redis://localhost:6379
-
-# Email Configuration (for notifications)
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=your-email@example.com
-SMTP_PASS=your-email-password
-SMTP_FROM=noreply@yourdomain.com
-
-# Analytics (optional)
-ANALYTICS_ENABLED=false
-GOOGLE_ANALYTICS_ID=GA-XXXXXXXXX
-
-# Rate Limiting
-RATE_LIMIT_WINDOW_MS=900000
-RATE_LIMIT_MAX_REQUESTS=100
-
-# Logging
-LOG_LEVEL=info
-LOG_FILE=./logs/app.log
-
-# Development Tools
-DEBUG=false
-ENABLE_QUERY_LOGGING=false
-
-# Production Settings
-ENABLE_COMPRESSION=true
-TRUST_PROXY=false
-
-# External APIs
-PAYMENT_PROVIDER_API_KEY=your-payment-api-key
-PAYMENT_PROVIDER_SECRET=your-payment-secret
-MAP_API_KEY=your-map-service-api-key
-
-# Monitoring
-SENTRY_DSN=your-sentry-dsn
-HEALTH_CHECK_ENDPOINT=/health
-
 # Security Notes:
 # 1. Never commit .env file to version control
 # 2. Use strong, unique secrets for each environment
 # 3. Rotate secrets regularly
 # 4. Use environment-specific values in production
+

--- a/server/README.md
+++ b/server/README.md
@@ -112,10 +112,11 @@ const newUser = await db.insert(users).values(validatedUserData);
 ### Environment Variables
 
 - `NODE_ENV`: Environment (development/production)
+- `PORT`: Server port (default: 3000)
 - `DATABASE_URL`: PostgreSQL connection string
 - `SESSION_SECRET`: Session encryption secret
-- `PORT`: Server port (default: 3000)
-- `SKIP_RATE_LIMITING`: Disable all rate limiting when set to `true` (defaults to enabled in development)
+- `TELEGRAM_BOT_TOKEN`: Telegram bot API token
+- `ADMIN_TELEGRAM_ID` (optional): Telegram user ID with admin access
 
 ### Middleware Stack
 

--- a/server/README.md
+++ b/server/README.md
@@ -116,7 +116,7 @@ const newUser = await db.insert(users).values(validatedUserData);
 - `DATABASE_URL`: PostgreSQL connection string
 - `SESSION_SECRET`: Session encryption secret
 - `TELEGRAM_BOT_TOKEN`: Telegram bot API token
-- `ADMIN_TELEGRAM_ID` (optional): Telegram user ID with admin access
+- `ADMIN_TELEGRAM_ID` (optional): Telegram user ID with admin access. If not set, no user will have admin privileges via Telegram, and admin-only features will be disabled or inaccessible.
 
 ### Middleware Stack
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -41,18 +41,6 @@ const envSchema = z.object({
   MAX_FILE_SIZE: z.string().transform(Number).pipe(z.number().positive()).default('5242880'), // 5MB
   UPLOAD_DIR: z.string().default('./uploads'),
 
-  // Redis (optional)
-  REDIS_URL: z.string().url().optional(),
-
-  // Email (optional)
-  SMTP_HOST: z.string().optional(),
-  SMTP_PORT: z.string().transform(Number).pipe(z.number().positive()).optional(),
-  SMTP_USER: z.string().optional(),
-  SMTP_PASS: z.string().optional(),
-
-  // Analytics (optional)
-  ANALYTICS_ID: z.string().optional(),
-
   // Logging
   LOG_LEVEL: z.enum(['error', 'warn', 'info', 'debug']).default('info'),
   LOG_FILE: z.string().optional(),


### PR DESCRIPTION
## Summary
- drop unused REDIS, SMTP and analytics variables
- streamline example env file to required settings
- update backend README with current env vars

## Testing
- `npm test`
- `npm run lint:check`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689cdc1fc72483278736b800e681bbd9